### PR TITLE
Copy no_dot_erlang.boot file in place

### DIFF
--- a/priv/templates/deb/rules
+++ b/priv/templates/deb/rules
@@ -38,6 +38,10 @@ install: build
 	if [ -f _build/default/rel/{{package_install_name}}/bin/start_clean.boot ]; then \
 		cp _build/default/rel/{{package_install_name}}/bin/start_clean.boot \
 				debian/{{package_name}}/usr/lib/{{package_install_name}}; fi
+	## copy the no_dot_erlang.boot
+	if [ -f _build/default/rel/{{package_install_name}}/bin/no_dot_erlang.boot ]; then \
+		cp _build/default/rel/{{package_install_name}}/bin/no_dot_erlang.boot \
+				debian/{{package_name}}/usr/lib/{{package_install_name}}; fi
 	dh_install
 	dh_installman
 	dh_installinit --name={{package_install_name}} --no-start

--- a/priv/templates/rpm/specfile
+++ b/priv/templates/rpm/specfile
@@ -102,6 +102,10 @@ if [ -d %{relpath}/bin ]; then \
 if [ -f %{relpath}/bin/start_clean.boot ]; then \
     cp %{relpath}/bin/start_clean.boot %{buildroot_lib}; fi
 
+# copy the no_dot_erlang.boot
+if [ -f %{relpath}/bin/no_dot_erlang.boot ]; then \
+    cp %{relpath}/bin/no_dot_erlang.boot %{buildroot_lib}; fi
+
 # Scan for manpages that are optional for each command in the package_commands list
 # If found:
 #     * install manpages


### PR DESCRIPTION
Needed for OTP 21 packages to boot.
- [x] tested deb packages
- [x] tested rpm packages