### PR TITLE
Make it possible to terminate long running commands

### DIFF
--- a/priv/base/env.sh
+++ b/priv/base/env.sh
@@ -244,7 +244,7 @@ check_user() {
 
         # This will drop priviledges into the runner user
         # It exec's in a new shell and the current shell will exit
-        exec su - $RUNNER_USER -c "$RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT $ESCAPED_ARGS"
+        exec su - $RUNNER_USER --session-command "$RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT $ESCAPED_ARGS"
     fi
 }
 


### PR DESCRIPTION
The `--session-command` is not as safe as `-c`, but since we're only
running our own code this is hopefully fine.

It's only been tested if `su --session-command` is available on
Centos7 and Debian 8, it is not certain if it's available everywhere.

Fixes vernemq/vernemq#644